### PR TITLE
Fix prompt context naming

### DIFF
--- a/chat_app/rag_store.py
+++ b/chat_app/rag_store.py
@@ -94,11 +94,11 @@ class RAGStore:
 		results = self.query(prompt, n_results)
 		texts = results['documents']
 
-		contex = '\n'.join(texts[0])
+                context = '\n'.join(texts[0])
 
-		contexed_prompt = f"From User: {prompt}\nContext to base your anwser: {contex}"
+                contexted_prompt = f"From User: {prompt}\nContext to base your answer: {context}"
 
-		return contexed_prompt
+                return contexted_prompt
 
 
 


### PR DESCRIPTION
## Summary
- rename `contex` variable and dependent prompt to `context`
- correct typo "anwser" to "answer" in prompt message
- return the properly named `contexted_prompt`

## Testing
- `pytest -q` *(fails: No module named 'flask', No module named 'torch')*
- `pip install flask torch -q` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68a2feabafc4832488c9a7362cf0da04