### PR TITLE
Refactor RAGStore into distinct storage and retrieval components

### DIFF
--- a/chat_app/__init__.py
+++ b/chat_app/__init__.py
@@ -1,5 +1,5 @@
 # chat_app/__init__.py
-__all__ = ["ChatApp", "LLMHandler", "RAGStore", "Embedder"]
+__all__ = ["ChatApp", "LLMHandler", "RAGStore", "RAGRetriever", "Embedder"]
 
 def __getattr__(name):
 	if name == "ChatApp":
@@ -11,6 +11,9 @@ def __getattr__(name):
 	if name == "RAGStore":
 		from .rag_store import RAGStore
 		return RAGStore
+	if name == "RAGRetriever":
+		from .rag_store import RAGRetriever
+		return RAGRetriever
 	if name == "Embedder":
 		from .embedder import Embedder
 		return Embedder

--- a/chat_app/chat_app.py
+++ b/chat_app/chat_app.py
@@ -1,15 +1,16 @@
 from flask import Flask, render_template, request, jsonify
 from user_agents import parse
 from .llm_handler import LLMHandler
-from .rag_store import RAGStore
+from .rag_store import RAGStore, RAGRetriever
 
 class ChatApp:
 	def __init__(self, model_id):
 		self.app = Flask(__name__)
 		self.llm = LLMHandler(model_id)
-		self.rag = RAGStore()
+		self.store = RAGStore()
+		self.rag = RAGRetriever(self.store)
 
-		# self.rag.add_file_to_store("C:\\Users\\wikto\\Documents\\Vobacom\\ChatVobacom\\What is RAG (Retrieval Augmented Generation)_ _ IBM.html")
+		# self.store.add_file_to_store("C:\\Users\\wikto\\Documents\\Vobacom\\ChatVobacom\\What is RAG (Retrieval Augmented Generation)_ _ IBM.html")
 
 		# Register routes
 		self.app.add_url_rule('/', view_func=self.index, methods=['GET'])

--- a/chat_app/rag_store.py
+++ b/chat_app/rag_store.py
@@ -48,47 +48,6 @@ class RAGStore:
 		added_ids = self.ingest([file_path], use_vlm=False, ocr=True)
 		return len(added_ids)
 
-	def query(self, query_text, n_results=5, where=None, include=("documents","metadatas","distances")):
-		"""
-		Query the vector store; returns Chroma results directly.
-		- Only pass `where` when provided; empty dicts can error.
-		- Do not include 'ids' in include (some backends disallow it for query()).
-		"""
-		q_emb = self.embedder.embed([query_text])[0]
-
-		kwargs = {
-			"query_embeddings": [q_emb],
-			"n_results": n_results,
-			"include": list(include)
-		}
-		if where:
-			kwargs["where"] = where
-
-		results = self.collection.query(**kwargs)
-		return results
-
-	def new_prompt_and_sources(self, prompt: str, n_results: int = 5):
-		results = self.query(prompt, n_results, include=("documents","metadatas","distances"))
-		texts_nested = results.get("documents", [[]])
-		metas_nested = results.get("metadatas", [[]])
-		dists_nested = results.get("distances", [[]])
-
-		contex = '\n'.join(texts_nested[0]) if (texts_nested and texts_nested[0]) else ""
-		contexted_prompt = f"From User: {prompt}\nContext to base your answer: {contex}"
-
-		sources = []
-		for i in range(len(metas_nested[0]) if metas_nested else 0):
-			m = metas_nested[0][i] or {}
-			d = dists_nested[0][i] if (dists_nested and dists_nested[0] and i < len(dists_nested[0])) else None
-			sources.append({
-				"source_file": m.get("source_file"),
-				"chunk_index": m.get("chunk_index"),
-				"page": m.get("page", -1),
-				"type": m.get("type", "text"),
-				"distance": d
-			})
-		return contexted_prompt, sources
-
 	# ---------- management helpers ----------------------------------------
 
 	def delete_source(self, file_path: str) -> int:
@@ -358,3 +317,55 @@ class RAGStore:
 			except Exception:
 				continue
 		return clean
+
+
+class RAGRetriever:
+	"""Encapsulates retrieval and prompt-building logic using a RAGStore."""
+
+	def __init__(self, store: RAGStore):
+		self.store = store
+
+	# ---------- retrieval API -------------------------------------------
+
+	def query(self, query_text, n_results=5, where=None, include=("documents", "metadatas", "distances")):
+		"""Query the vector store via the associated RAGStore."""
+		q_emb = self.store.embedder.embed([query_text])[0]
+
+		kwargs = {
+			"query_embeddings": [q_emb],
+			"n_results": n_results,
+			"include": list(include),
+		}
+		if where:
+			kwargs["where"] = where
+
+		return self.store.collection.query(**kwargs)
+
+	def new_prompt_and_sources(self, prompt: str, n_results: int = 5):
+		"""Return a prompt augmented with retrieved context and the source metadata."""
+		results = self.query(prompt, n_results, include=("documents", "metadatas", "distances"))
+		texts_nested = results.get("documents", [[]])
+		metas_nested = results.get("metadatas", [[]])
+		dists_nested = results.get("distances", [[]])
+
+		contex = '\n'.join(texts_nested[0]) if (texts_nested and texts_nested[0]) else ""
+		contexted_prompt = f"From User: {prompt}\nContext to base your answer: {contex}"
+
+		sources = []
+		for i in range(len(metas_nested[0]) if metas_nested else 0):
+			m = metas_nested[0][i] or {}
+			d = (
+				dists_nested[0][i]
+				if (dists_nested and dists_nested[0] and i < len(dists_nested[0]))
+				else None
+			)
+			sources.append(
+				{
+					"source_file": m.get("source_file"),
+					"chunk_index": m.get("chunk_index"),
+					"page": m.get("page", -1),
+					"type": m.get("type", "text"),
+					"distance": d,
+				}
+			)
+		return contexted_prompt, sources

--- a/tests/test_chatapp.py
+++ b/tests/test_chatapp.py
@@ -6,16 +6,19 @@ from chat_app.chat_app import ChatApp
 class TestChatApp(unittest.TestCase):
 	def setUp(self):
 		patcher = patch('chat_app.chat_app.LLMHandler')
-		patcher_rag = patch('chat_app.chat_app.RAGStore')
-		
+		patcher_store = patch('chat_app.chat_app.RAGStore')
+		patcher_rag = patch('chat_app.chat_app.RAGRetriever')
+
 		self.MockLLMHandler = patcher.start()
-		self.MockRAGStore = patcher_rag.start()
-		
+		self.MockRAGStore = patcher_store.start()
+		self.MockRAGRetriever = patcher_rag.start()
+
 		self.addCleanup(patcher.stop)
+		self.addCleanup(patcher_store.stop)
 		self.addCleanup(patcher_rag.stop)
 
 		mock_llm_instance = self.MockLLMHandler.return_value
-		mock_rag_instance = self.MockRAGStore.return_value
+		mock_rag_instance = self.MockRAGRetriever.return_value
 		mock_llm_instance.chat_next.return_value = "Mocked response"
 		mock_rag_instance.new_prompt_and_sources.return_value = ("Mocked prompt", "Mocked sources")
 
@@ -56,7 +59,7 @@ class TestChatApp(unittest.TestCase):
 
 		self.assertEqual(response.status_code, 200)
 		self.assertEqual(data['response'], "Mocked response")
-		self.MockRAGStore.return_value.new_prompt_and_sources.assert_called_once_with("Hello")
+		self.MockRAGRetriever.return_value.new_prompt_and_sources.assert_called_once_with("Hello")
 		self.MockLLMHandler.return_value.chat_next.assert_called_once_with("Mocked prompt")
 
 


### PR DESCRIPTION
## Summary
- Split monolithic `RAGStore` into `RAGStore` for data management and new `RAGRetriever` for retrieval logic.
- Updated `ChatApp` to compose a store with a retriever, clarifying responsibilities.
- Adjusted tests to reflect the new architecture.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68a5d274a5548324b5f131062c7accb2