### PR TITLE
Add endpoint for folder ingestion with recursive option

### DIFF
--- a/chat_app/__main__.py
+++ b/chat_app/__main__.py
@@ -4,7 +4,7 @@ from .scanner import Scanner
 
 if __name__ == "__main__":
 	storage = RAGStore()
-	paths = Scanner().scan("C:\\Users\\wikto\\Documents\\Vobacom\\Files")
-	storage.ingest(paths)
-	# app = ChatApp("NousResearch/Hermes-3-Llama-3.1-8B")
-	# app.run(debug=True, host="127.0.0.1", port=5000, use_reloader=False)
+	# paths = Scanner().scan("C:\\Users\\wikto\\Documents\\Vobacom\\Files")
+	# storage.ingest(paths)
+	app = ChatApp("NousResearch/Hermes-3-Llama-3.1-8B")
+	app.run(debug=True, host="127.0.0.1", port=5000, use_reloader=False)

--- a/chat_app/chat_app.py
+++ b/chat_app/chat_app.py
@@ -5,65 +5,86 @@ from user_agents import parse
 from .llm_handler import LLMHandler
 from .rag_store import RAGStore
 from .rag_retriever import RAGRetriever
+from .scanner import Scanner
+
 
 logger = logging.getLogger(__name__)
 
+
 class ChatApp:
-	def __init__(self, model_id):
-		if not logging.getLogger().hasHandlers():
-			logging.basicConfig(level=logging.INFO)
-		self.app = Flask(__name__)
-		self.llm = LLMHandler(model_id)
-		self.store = RAGStore()
-		self.rag = RAGRetriever(self.store)
-		logger.info("ChatApp initialized with model %s", model_id)
+    def __init__(self, model_id):
+        if not logging.getLogger().hasHandlers():
+            logging.basicConfig(level=logging.INFO)
+        self.app = Flask(__name__)
+        self.llm = LLMHandler(model_id)
+        self.store = RAGStore()
+        self.rag = RAGRetriever(self.store)
+        self.scanner = Scanner()
+        logger.info("ChatApp initialized with model %s", model_id)
 
-		self.app.add_url_rule('/', view_func=self.index, methods=['GET'])
-		self.app.add_url_rule('/chat', view_func=self.chat, methods=['POST'])
-		self.app.add_url_rule('/rag', view_func=self.rag_chat, methods=['POST'])
+        self.app.add_url_rule('/', view_func=self.index, methods=['GET'])
+        self.app.add_url_rule('/chat', view_func=self.chat, methods=['POST'])
+        self.app.add_url_rule('/rag', view_func=self.rag_chat, methods=['POST'])
+        self.app.add_url_rule('/ingest', view_func=self.ingest_folder, methods=['POST'])
 
-	def index(self):
-		try:
-			user_agent_string = request.headers.get('User-Agent', '')
-			logger.info("Serving index for user agent: %s", user_agent_string)
-			user_agent = parse(user_agent_string)
-			if user_agent.is_mobile:
-				return render_template("index_mobile.html")
-			else:
-				return render_template("index_desktop.html")
-		except Exception as e:
-			logger.exception("Error in index route: %s", e)
-			return jsonify({'error': str(e)})
+    def index(self):
+        try:
+            user_agent_string = request.headers.get('User-Agent', '')
+            logger.info("Serving index for user agent: %s", user_agent_string)
+            user_agent = parse(user_agent_string)
+            if user_agent.is_mobile:
+                return render_template("index_mobile.html")
+            else:
+                return render_template("index_desktop.html")
+        except Exception as e:
+            logger.exception("Error in index route: %s", e)
+            return jsonify({'error': str(e)})
 
-	def chat(self):
-		try:
-			user_message = request.json['message']
-			logger.info("Chat message received: %s", user_message)
-			llm_response = self.llm.chat_next(user_message)
-			return jsonify({'response': llm_response}), 200
-		except Exception as e:
-			logger.exception("Error in chat route: %s", e)
-			return jsonify({'error': str(e)})
+    def chat(self):
+        try:
+            user_message = request.json['message']
+            logger.info("Chat message received: %s", user_message)
+            llm_response = self.llm.chat_next(user_message)
+            return jsonify({'response': llm_response}), 200
+        except Exception as e:
+            logger.exception("Error in chat route: %s", e)
+            return jsonify({'error': str(e)})
 
-	def rag_chat(self):
-		try:
-			user_message = request.json['message']
-			logger.info("RAG chat message received: %s", user_message)
+    def rag_chat(self):
+        try:
+            user_message = request.json['message']
+            logger.info("RAG chat message received: %s", user_message)
 
-			messages, sources = self.rag.build_messages(user_message, n_results=5)
-			logger.info("Built RAG messages with %d sources", len(sources))
+            messages, sources = self.rag.build_messages(user_message, n_results=5)
+            logger.info("Built RAG messages with %d sources", len(sources))
 
-			# Stateless RAG turn: reset history so prior chit-chat doesn't leak
-			llm_response = self.llm.chat_messages(messages, reset=True)
-			return jsonify({'response': llm_response, 'sources': sources}), 200
-		except Exception as e:
-			logger.exception("Error in rag route: %s", e)
-			return jsonify({'error': str(e)})
+            # Stateless RAG turn: reset history so prior chit-chat doesn't leak
+            llm_response = self.llm.chat_messages(messages, reset=True)
+            return jsonify({'response': llm_response, 'sources': sources}), 200
+        except Exception as e:
+            logger.exception("Error in rag route: %s", e)
+            return jsonify({'error': str(e)})
 
-	def run(self, **kwargs):
-		logger.info("Starting ChatApp server with args: %s", kwargs)
-		self.app.run(**kwargs)
+    def ingest_folder(self):
+        try:
+            data = request.json or {}
+            folder = data.get('folder')
+            recursive = bool(data.get('recursive', False))
+            if not folder:
+                raise ValueError('folder is required')
+            files = self.scanner.scan(folder, recursively=recursive)
+            added = self.store.ingest(files)
+            return jsonify({'files_ingested': len(added)}), 200
+        except Exception as e:
+            logger.exception("Error in ingest route: %s", e)
+            return jsonify({'error': str(e)})
+
+    def run(self, **kwargs):
+        logger.info("Starting ChatApp server with args: %s", kwargs)
+        self.app.run(**kwargs)
+
 
 if __name__ == '__main__':
-	chat_app = ChatApp("NousResearch/Hermes-3-Llama-3.1-8B")
-	chat_app.run(debug=True, use_reloader=False)
+    chat_app = ChatApp("NousResearch/Hermes-3-Llama-3.1-8B")
+    chat_app.run(debug=True, use_reloader=False)
+

--- a/chat_app/chat_app.py
+++ b/chat_app/chat_app.py
@@ -45,7 +45,15 @@ class ChatApp:
             user_message = request.json['message']
             logger.info("Chat message received: %s", user_message)
             llm_response = self.llm.chat_next(user_message)
-            return jsonify({'response': llm_response}), 200
+            return jsonify({
+                'message': {
+                    'format': 'markdown',
+                    'content': llm_response,
+                },
+                'meta': {
+                    'mode': 'llm',
+                }
+            }), 200
         except Exception as e:
             logger.exception("Error in chat route: %s", e)
             return jsonify({'error': str(e)})
@@ -60,7 +68,16 @@ class ChatApp:
 
             # Stateless RAG turn: reset history so prior chit-chat doesn't leak
             llm_response = self.llm.chat_messages(messages, reset=True)
-            return jsonify({'response': llm_response, 'sources': sources}), 200
+            return jsonify({
+                'message': {
+                    'format': 'markdown',
+                    'content': llm_response,
+                },
+                'meta': {
+                    'sources': sources,
+                    'mode': 'rag',
+                }
+            }), 200
         except Exception as e:
             logger.exception("Error in rag route: %s", e)
             return jsonify({'error': str(e)})

--- a/chat_app/templates/index_desktop.html
+++ b/chat_app/templates/index_desktop.html
@@ -233,12 +233,17 @@
 			color: #a0aec0;
 		}
 
-		.chat-input:focus {
-			outline: none;
-			border-color: #f59e0b;
-			box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
-			background: rgba(74, 85, 104, 0.95);
-		}
+                .chat-input:focus {
+                        outline: none;
+                        border-color: #f59e0b;
+                        box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
+                        background: rgba(74, 85, 104, 0.95);
+                }
+
+                .chat-input.dragover {
+                        border-color: #f59e0b;
+                        background: rgba(74, 85, 104, 0.9);
+                }
 
 		.send-button {
 			padding: 18px 28px;
@@ -262,11 +267,23 @@
 			box-shadow: 0 8px 20px rgba(245, 158, 11, 0.4);
 		}
 
-		.send-button:disabled {
-			opacity: 0.6;
-			cursor: not-allowed;
-			transform: none;
-		}
+                .send-button:disabled {
+                        opacity: 0.6;
+                        cursor: not-allowed;
+                        transform: none;
+                }
+
+                .recursive-option {
+                        display: flex;
+                        align-items: center;
+                        color: #e2e8f0;
+                        gap: 8px;
+                }
+
+                .recursive-option input {
+                        width: 16px;
+                        height: 16px;
+                }
 
 		.error-message {
 			background: rgba(220, 38, 38, 0.2);
@@ -329,18 +346,26 @@
 			<div class="header-center">
 				<h1>VobaChat</h1>
 			</div>
-			<div class="header-right">
-				<div class="mode-toggle">
-					<span class="mode-label" id="modeLabel">LLM</span>
-					<div class="toggle-switch" id="modeToggle">
-						<div class="toggle-slider"></div>
-					</div>
-					<span class="mode-label">RAG</span>
-				</div>
-			</div>
-		</div>
-		
-		<div class="chat-messages" id="chatMessages">
+                <div class="header-right">
+                        <div class="mode-toggle">
+                                <span class="mode-label" id="modeLabel">LLM</span>
+                                <div class="toggle-switch" id="modeToggle">
+                                        <div class="toggle-slider"></div>
+                                </div>
+                                <span class="mode-label">RAG</span>
+                        </div>
+                </div>
+        </div>
+
+        <div class="chat-input-container">
+                <div class="input-group">
+                        <input type="text" class="chat-input" id="folderPath" placeholder="Folder path">
+                        <label class="recursive-option"><input type="checkbox" id="recursive">Recursive</label>
+                        <button class="send-button" id="ingestButton">Ingest</button>
+                </div>
+        </div>
+
+        <div class="chat-messages" id="chatMessages">
 			<div class="bot-message">
 				Hello! I'm VobaChat, your AI assistant. How can I help you today?
 			</div>
@@ -370,14 +395,40 @@
 	</div>
 
 	<script>
-		const chatMessages = document.getElementById('chatMessages');
-		const messageInput = document.getElementById('messageInput');
-		const sendButton = document.getElementById('sendButton');
-		const typingIndicator = document.getElementById('typingIndicator');
-		const modeToggle = document.getElementById('modeToggle');
-		const modeLabel = document.getElementById('modeLabel');
+                const chatMessages = document.getElementById('chatMessages');
+                const messageInput = document.getElementById('messageInput');
+                const sendButton = document.getElementById('sendButton');
+                const typingIndicator = document.getElementById('typingIndicator');
+                const modeToggle = document.getElementById('modeToggle');
+                const modeLabel = document.getElementById('modeLabel');
+                const folderInput = document.getElementById('folderPath');
+                const ingestButton = document.getElementById('ingestButton');
+                const recursiveCheckbox = document.getElementById('recursive');
 
-		let isRAGMode = false;
+                window.addEventListener('dragover', (e) => e.preventDefault());
+                window.addEventListener('drop', (e) => e.preventDefault());
+
+                folderInput.addEventListener('dragover', (e) => {
+                        e.preventDefault();
+                        folderInput.classList.add('dragover');
+                });
+                folderInput.addEventListener('dragleave', () => {
+                        folderInput.classList.remove('dragover');
+                });
+                folderInput.addEventListener('drop', (e) => {
+                        e.preventDefault();
+                        folderInput.classList.remove('dragover');
+                        let droppedPath = e.dataTransfer.getData('text/plain') || e.dataTransfer.getData('text/uri-list');
+                        if (!droppedPath && e.dataTransfer.files.length > 0) {
+                                const file = e.dataTransfer.files[0];
+                                droppedPath = file.path || file.name;
+                        }
+                        if (droppedPath) {
+                                folderInput.value = droppedPath.replace(/^file:\/\//, '');
+                        }
+                });
+
+                let isRAGMode = false;
 
 		// Toggle mode functionality
 		modeToggle.addEventListener('click', function() {
@@ -403,7 +454,8 @@
 			}
 		});
 
-		sendButton.addEventListener('click', sendMessage);
+                sendButton.addEventListener('click', sendMessage);
+                ingestButton.addEventListener('click', ingestFolder);
 
 		function addMessage(content, isUser = false, isError = false) {
 			const messageDiv = document.createElement('div');
@@ -422,9 +474,38 @@
 			chatMessages.scrollTop = chatMessages.scrollHeight;
 		}
 
-		function hideTypingIndicator() {
-			typingIndicator.style.display = 'none';
-		}
+                function hideTypingIndicator() {
+                        typingIndicator.style.display = 'none';
+                }
+
+                function ingestFolder() {
+                        const folder = folderInput.value.trim();
+                        const recursive = recursiveCheckbox.checked;
+                        if (!folder) return;
+                        ingestButton.disabled = true;
+                        fetch('/ingest', {
+                                method: 'POST',
+                                headers: {
+                                        'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify({ folder: folder, recursive: recursive })
+                        })
+                        .then(response => response.json())
+                        .then(data => {
+                                if (data.error) {
+                                        addMessage(data.error, false, true);
+                                } else {
+                                        addMessage(`Ingested ${data.files_ingested} files.`, false);
+                                }
+                        })
+                        .catch(error => {
+                                console.error('Error:', error);
+                                addMessage('Error ingesting folder.', false, true);
+                        })
+                        .finally(() => {
+                                ingestButton.disabled = false;
+                        });
+                }
 
 		function sendMessage() {
 			const message = messageInput.value.trim();

--- a/chat_app/templates/index_desktop.html
+++ b/chat_app/templates/index_desktop.html
@@ -337,7 +337,20 @@
 				display: none;
 			}
 		}
+		.user-message, .bot-message, .error-message { white-space: pre-wrap; }
+                .message { overflow-wrap: anywhere; word-break: break-word; }
+                .message p { margin: 0 0 .6em; }
+                .message p:last-child { margin-bottom: 0; }
+                .message ul, .message ol { margin: .6em 0; padding-left: 1.25rem; }
+                .message pre, .message code { white-space: pre-wrap; word-break: break-word; }
+                .message pre { overflow-x: auto; }
+                .message img { max-width: 100%; height: auto; display: block; }
+                .message table { display: block; max-width: 100%; overflow-x: auto; border-collapse: collapse; }
+                .message th, .message td { border-bottom: 1px solid rgba(255,255,255,.08); padding: .25rem .5rem; }
 	</style>
+	<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+
 </head>
 <body>
 	<div class="chat-container">
@@ -366,7 +379,7 @@
         </div>
 
         <div class="chat-messages" id="chatMessages">
-			<div class="bot-message">
+			<div class="message bot-message">
 				Hello! I'm VobaChat, your AI assistant. How can I help you today?
 			</div>
 		</div>
@@ -457,14 +470,44 @@
                 sendButton.addEventListener('click', sendMessage);
                 ingestButton.addEventListener('click', ingestFolder);
 
-		function addMessage(content, isUser = false, isError = false) {
-			const messageDiv = document.createElement('div');
-			if (isError) {
-				messageDiv.className = 'error-message';
+		function normalizeMessagePayload(data) {
+			// Back-compat with old `{ response: "..." }`
+			if (data?.message && typeof data.message.content === 'string') return data.message;
+			if (typeof data?.response === 'string') return { format: 'text', content: data.response };
+			return { format: 'text', content: String(data ?? '') };
+		}
+
+		function renderContentInto(el, payload) {
+			const { format, content } = payload || {};
+			if (format === 'markdown') {
+				const html = DOMPurify.sanitize(marked.parse(content || ''));
+				el.innerHTML = html;
 			} else {
-				messageDiv.className = isUser ? 'user-message' : 'bot-message';
+				el.textContent = content || '';
+				el.style.whiteSpace = 'pre-wrap'; // keep \n in plaintext
 			}
-			messageDiv.textContent = content;
+		}
+
+		function addMessage(payloadOrString, isUser = false, isError = false) {
+			const messageDiv = document.createElement('div');
+			messageDiv.className = isError
+                                ? 'message error-message'
+                                : (isUser ? 'message user-message' : 'message bot-message');
+
+			// Keep user/error as plain text for safety
+			if (isUser || isError) {
+				const text = typeof payloadOrString === 'string'
+					? payloadOrString
+					: (payloadOrString?.content ?? String(payloadOrString ?? ''));
+				messageDiv.textContent = text;
+				messageDiv.style.whiteSpace = 'pre-wrap';
+			} else {
+				const payload = (typeof payloadOrString === 'string')
+					? { format: 'text', content: payloadOrString }
+					: payloadOrString;
+				renderContentInto(messageDiv, payload);
+			}
+
 			chatMessages.appendChild(messageDiv);
 			chatMessages.scrollTop = chatMessages.scrollHeight;
 		}
@@ -492,12 +535,15 @@
                         })
                         .then(response => response.json())
                         .then(data => {
-                                if (data.error) {
-                                        addMessage(data.error, false, true);
-                                } else {
-                                        addMessage(`Ingested ${data.files_ingested} files.`, false);
-                                }
-                        })
+				hideTypingIndicator();
+				if (data.error) {
+					addMessage(data.error, false, true);
+					return;
+				}
+				const payload = normalizeMessagePayload(data);
+				addMessage(payload, false);
+			})
+
                         .catch(error => {
                                 console.error('Error:', error);
                                 addMessage('Error ingesting folder.', false, true);
@@ -535,13 +581,15 @@
 			})
 			.then(response => response.json())
 			.then(data => {
-				hideTypingIndicator();
-				if (data.error) {
-					addMessage(data.error, false, true);
-				} else {
-					addMessage(data.response, false);
-				}
-			})
+                                hideTypingIndicator();
+                                if (data.error) {
+                                        addMessage(data.error, false, true);
+                                        return;
+                                }
+                                const payload = normalizeMessagePayload(data);
+                                addMessage(payload, false);
+                        })
+
 			.catch(error => {
 				hideTypingIndicator();
 				console.error('Error:', error);

--- a/chat_app/templates/index_mobile.html
+++ b/chat_app/templates/index_mobile.html
@@ -1,222 +1,222 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>VobaChat</title>
-	<style>
-		* {
-			margin: 0;
-			padding: 0;
-			box-sizing: border-box;
-		}
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>VobaChat</title>
+        <style>
+                * {
+                        margin: 0;
+                        padding: 0;
+                        box-sizing: border-box;
+                }
 
-		body {
-			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-			background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
-			min-height: 100vh;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			padding: 10px;
-		}
+                body {
+                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+                        background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%);
+                        min-height: 100vh;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        padding: 10px;
+                }
 
-		.chat-container {
-			background: rgba(45, 55, 72, 0.95);
-			backdrop-filter: blur(15px);
-			border-radius: 25px;
-			box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-			border: 1px solid rgba(255, 193, 7, 0.2);
-			width: 100%;
-			max-width: 400px;
-			height: 85vh;
-			display: flex;
-			flex-direction: column;
-			overflow: hidden;
-		}
+                .chat-container {
+                        background: rgba(45, 55, 72, 0.95);
+                        backdrop-filter: blur(15px);
+                        border-radius: 25px;
+                        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+                        border: 1px solid rgba(255, 193, 7, 0.2);
+                        width: 100%;
+                        max-width: 400px;
+                        height: 85vh;
+                        display: flex;
+                        flex-direction: column;
+                        overflow: hidden;
+                }
 
-		.chat-header {
-			background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-			color: #1a202c;
-			padding: 15px 20px;
-			position: relative;
-			border-radius: 25px 25px 0 0;
-			display: flex;
-			flex-direction: column;
-			gap: 12px;
-			align-items: center;
-		}
+                .chat-header {
+                        background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+                        color: #1a202c;
+                        padding: 15px 20px;
+                        position: relative;
+                        border-radius: 25px 25px 0 0;
+                        display: flex;
+                        flex-direction: column;
+                        gap: 12px;
+                        align-items: center;
+                }
 
-		.header-title {
-			font-size: 1.4rem;
-			font-weight: 600;
-			margin: 0;
-		}
+                .header-title {
+                        font-size: 1.4rem;
+                        font-weight: 600;
+                        margin: 0;
+                }
 
-		.mode-toggle {
-			display: flex;
-			align-items: center;
-			gap: 8px;
-			background: rgba(26, 32, 44, 0.2);
-			padding: 6px 12px;
-			border-radius: 16px;
-			font-size: 0.8rem;
-			font-weight: 500;
-		}
+                .mode-toggle {
+                        display: flex;
+                        align-items: center;
+                        gap: 8px;
+                        background: rgba(26, 32, 44, 0.2);
+                        padding: 6px 12px;
+                        border-radius: 16px;
+                        font-size: 0.8rem;
+                        font-weight: 500;
+                }
 
-		.toggle-switch {
-			position: relative;
-			width: 40px;
-			height: 20px;
-			background: rgba(26, 32, 44, 0.4);
-			border-radius: 10px;
-			cursor: pointer;
-			transition: all 0.3s ease;
-		}
+                .toggle-switch {
+                        position: relative;
+                        width: 40px;
+                        height: 20px;
+                        background: rgba(26, 32, 44, 0.4);
+                        border-radius: 10px;
+                        cursor: pointer;
+                        transition: all 0.3s ease;
+                }
 
-		.toggle-switch.active {
-			background: rgba(16, 185, 129, 0.8);
-		}
+                .toggle-switch.active {
+                        background: rgba(16, 185, 129, 0.8);
+                }
 
-		.toggle-slider {
-			position: absolute;
-			top: 2px;
-			left: 2px;
-			width: 16px;
-			height: 16px;
-			background: #1a202c;
-			border-radius: 50%;
-			transition: all 0.3s ease;
-			box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-		}
+                .toggle-slider {
+                        position: absolute;
+                        top: 2px;
+                        left: 2px;
+                        width: 16px;
+                        height: 16px;
+                        background: #1a202c;
+                        border-radius: 50%;
+                        transition: all 0.3s ease;
+                        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+                }
 
-		.toggle-switch.active .toggle-slider {
-			transform: translateX(20px);
-		}
+                .toggle-switch.active .toggle-slider {
+                        transform: translateX(20px);
+                }
 
-		.mode-label {
-			font-weight: 600;
-			text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-			font-size: 0.75rem;
-		}
+                .mode-label {
+                        font-weight: 600;
+                        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+                        font-size: 0.75rem;
+                }
 
-		.chat-messages {
-			flex: 1;
-			overflow-y: auto;
-			padding: 15px;
-			display: flex;
-			flex-direction: column;
-			gap: 12px;
-			background: #2d3748;
-		}
+                .chat-messages {
+                        flex: 1;
+                        overflow-y: auto;
+                        padding: 15px;
+                        display: flex;
+                        flex-direction: column;
+                        gap: 12px;
+                        background: #2d3748;
+                }
 
-		.message {
-			max-width: 85%;
-			padding: 12px 16px;
-			border-radius: 20px;
-			word-wrap: break-word;
-			animation: slideIn 0.3s ease-out;
-			font-size: 0.95rem;
-			line-height: 1.4;
-		}
+                .message {
+                        max-width: 85%;
+                        padding: 12px 16px;
+                        border-radius: 20px;
+                        word-wrap: break-word;
+                        animation: slideIn 0.3s ease-out;
+                        font-size: 0.95rem;
+                        line-height: 1.4;
+                }
 
-		@keyframes slideIn {
-			from {
-				opacity: 0;
-				transform: translateY(10px);
-			}
-			to {
-				opacity: 1;
-				transform: translateY(0);
-			}
-		}
+                @keyframes slideIn {
+                        from {
+                                opacity: 0;
+                                transform: translateY(10px);
+                        }
+                        to {
+                                opacity: 1;
+                                transform: translateY(0);
+                        }
+                }
 
-		.user-message {
-			align-self: flex-end;
-			background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-			color: #1a202c;
-			margin-left: auto;
-			font-weight: 500;
-			border-radius: 5px;
-			padding: 5px 5px;
-		}
+                .user-message {
+                        align-self: flex-end;
+                        background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+                        color: #1a202c;
+                        margin-left: auto;
+                        font-weight: 500;
+                        border-radius: 5px;
+                        padding: 5px 5px;
+                }
 
-		.bot-message {
-			align-self: flex-start;
-			background: rgba(74, 85, 104, 0.8);
-			color: #e2e8f0;
-			border: 2px solid rgba(255, 193, 7, 0.3);
-			border-radius: 5px;
-			padding: 5px 5px;
-		}
+                .bot-message {
+                        align-self: flex-start;
+                        background: rgba(74, 85, 104, 0.8);
+                        color: #e2e8f0;
+                        border: 2px solid rgba(255, 193, 7, 0.3);
+                        border-radius: 5px;
+                        padding: 5px 5px;
+                }
 
-		.typing-indicator {
-			display: none;
-			align-self: flex-start;
-			background: rgba(74, 85, 104, 0.6);
-			border: 1px solid rgba(255, 193, 7, 0.3);
-			padding: 12px 16px;
-			border-radius: 20px;
-			margin-bottom: 12px;
-		}
+                .typing-indicator {
+                        display: none;
+                        align-self: flex-start;
+                        background: rgba(74, 85, 104, 0.6);
+                        border: 1px solid rgba(255, 193, 7, 0.3);
+                        padding: 12px 16px;
+                        border-radius: 20px;
+                        margin-bottom: 12px;
+                }
 
-		.typing-dots {
-			display: flex;
-			gap: 4px;
-		}
+                .typing-dots {
+                        display: flex;
+                        gap: 4px;
+                }
 
-		.typing-dot {
-			width: 6px;
-			height: 6px;
-			border-radius: 50%;
-			background: #fbbf24;
-			animation: typing 1.4s infinite ease-in-out;
-		}
+                .typing-dot {
+                        width: 6px;
+                        height: 6px;
+                        border-radius: 50%;
+                        background: #fbbf24;
+                        animation: typing 1.4s infinite ease-in-out;
+                }
 
-		.typing-dot:nth-child(1) { animation-delay: -0.32s; }
-		.typing-dot:nth-child(2) { animation-delay: -0.16s; }
+                .typing-dot:nth-child(1) { animation-delay: -0.32s; }
+                .typing-dot:nth-child(2) { animation-delay: -0.16s; }
 
-		@keyframes typing {
-			0%, 80%, 100% { transform: scale(0); }
-			40% { transform: scale(1); }
-		}
+                @keyframes typing {
+                        0%, 80%, 100% { transform: scale(0); }
+                        40% { transform: scale(1); }
+                }
 
-		@keyframes pulse {
-			0%, 100% { opacity: 1; }
-			50% { opacity: 0.5; }
-		}
+                @keyframes pulse {
+                        0%, 100% { opacity: 1; }
+                        50% { opacity: 0.5; }
+                }
 
-		.chat-input-container {
-			padding: 15px;
-			background: rgba(45, 55, 72, 0.95);
-			border-top: 1px solid rgba(255, 193, 7, 0.3);
-			border-radius: 0 0 25px 25px;
-		}
+                .chat-input-container {
+                        padding: 15px;
+                        background: rgba(45, 55, 72, 0.95);
+                        border-top: 1px solid rgba(255, 193, 7, 0.3);
+                        border-radius: 0 0 25px 25px;
+                }
 
-		.input-group {
-			display: flex;
-			gap: 8px;
-			align-items: flex-end;
-		}
+                .input-group {
+                        display: flex;
+                        gap: 8px;
+                        align-items: flex-end;
+                }
 
-		.chat-input {
-			flex: 1;
-			padding: 12px 16px;
-			border: 2px solid rgba(255, 193, 7, 0.4);
-			border-radius: 20px;
-			font-size: 0.95rem;
-			resize: none;
-			min-height: 44px;
-			max-height: 100px;
-			font-family: inherit;
-			transition: all 0.3s ease;
-			background: rgba(74, 85, 104, 0.8);
-			color: #e2e8f0;
-		}
+                .chat-input {
+                        flex: 1;
+                        padding: 12px 16px;
+                        border: 2px solid rgba(255, 193, 7, 0.4);
+                        border-radius: 20px;
+                        font-size: 0.95rem;
+                        resize: none;
+                        min-height: 44px;
+                        max-height: 100px;
+                        font-family: inherit;
+                        transition: all 0.3s ease;
+                        background: rgba(74, 85, 104, 0.8);
+                        color: #e2e8f0;
+                }
 
-		.chat-input::placeholder {
-			color: #a0aec0;
-		}
+                .chat-input::placeholder {
+                        color: #a0aec0;
+                }
 
                 .chat-input:focus {
                         outline: none;
@@ -230,27 +230,27 @@
                         background: rgba(74, 85, 104, 0.9);
                 }
 
-		.send-button {
-			padding: 12px 18px;
-			background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-			color: #1a202c;
-			border: none;
-			border-radius: 20px;
-			font-size: 0.95rem;
-			font-weight: 600;
-			cursor: pointer;
-			transition: all 0.3s ease;
-			display: flex;
-			align-items: center;
-			gap: 6px;
-			min-width: 70px;
-			justify-content: center;
-		}
+                .send-button {
+                        padding: 12px 18px;
+                        background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+                        color: #1a202c;
+                        border: none;
+                        border-radius: 20px;
+                        font-size: 0.95rem;
+                        font-weight: 600;
+                        cursor: pointer;
+                        transition: all 0.3s ease;
+                        display: flex;
+                        align-items: center;
+                        gap: 6px;
+                        min-width: 70px;
+                        justify-content: center;
+                }
 
-		.send-button:hover {
-			transform: translateY(-2px);
-			box-shadow: 0 6px 16px rgba(245, 158, 11, 0.4);
-		}
+                .send-button:hover {
+                        transform: translateY(-2px);
+                        box-shadow: 0 6px 16px rgba(245, 158, 11, 0.4);
+                }
 
                 .send-button:disabled {
                         opacity: 0.6;
@@ -271,37 +271,41 @@
                         height: 14px;
                 }
 
-		.error-message {
-			background: rgba(220, 38, 38, 0.2);
-			color: #fca5a5;
-			border: 1px solid rgba(220, 38, 38, 0.4);
-			padding: 12px 16px;
-			border-radius: 20px;
-			align-self: flex-start;
-		}
+                .error-message {
+                        background: rgba(220, 38, 38, 0.2);
+                        color: #fca5a5;
+                        border: 1px solid rgba(220, 38, 38, 0.4);
+                        padding: 12px 16px;
+                        border-radius: 20px;
+                        align-self: flex-start;
+                }
 
-		/* Scrollbar styling */
-		.chat-messages::-webkit-scrollbar {
-			width: 4px;
-		}
+                /* Scrollbar styling */
+                .chat-messages::-webkit-scrollbar {
+                        width: 4px;
+                }
 
-		.chat-messages::-webkit-scrollbar-track {
-			background: rgba(74, 85, 104, 0.3);
-			border-radius: 8px;
-		}
+                .chat-messages::-webkit-scrollbar-track {
+                        background: rgba(74, 85, 104, 0.3);
+                        border-radius: 8px;
+                }
 
-		.chat-messages::-webkit-scrollbar-thumb {
-			background: rgba(255, 193, 7, 0.6);
-			border-radius: 8px;
-		}
+                .chat-messages::-webkit-scrollbar-thumb {
+                        background: rgba(255, 193, 7, 0.6);
+                        border-radius: 8px;
+                }
 
-		.chat-messages::-webkit-scrollbar-thumb:hover {
-			background: rgba(255, 193, 7, 0.8);
-		}
-	</style>
+                .chat-messages::-webkit-scrollbar-thumb:hover {
+                        background: rgba(255, 193, 7, 0.8);
+                }
+                
+        </style>
+        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+
 </head>
 <body>
-	<div class="chat-container">
+        <div class="chat-container">
                 <div class="chat-header">
                         <h1 class="header-title">VobaChat</h1>
                         <div class="mode-toggle">
@@ -322,35 +326,35 @@
                 </div>
 
                 <div class="chat-messages" id="chatMessages">
-			<div class="bot-message">
-				Hello! I'm VobaChat, your AI assistant. How can I help you today?
-			</div>
-		</div>
-		
-		<div class="typing-indicator" id="typingIndicator">
-			<div class="typing-dots">
-				<div class="typing-dot"></div>
-				<div class="typing-dot"></div>
-				<div class="typing-dot"></div>
-			</div>
-		</div>
-		
-		<div class="chat-input-container">
-			<div class="input-group">
-				<textarea 
-					class="chat-input" 
-					id="messageInput" 
-					placeholder="Type your message here..." 
-					rows="1"
-				></textarea>
-				<button class="send-button" id="sendButton">
-					Send
-				</button>
-			</div>
-		</div>
-	</div>
+                        <div class="bot-message">
+                                Hello! I'm VobaChat, your AI assistant. How can I help you today?
+                        </div>
+                </div>
+                
+                <div class="typing-indicator" id="typingIndicator">
+                        <div class="typing-dots">
+                                <div class="typing-dot"></div>
+                                <div class="typing-dot"></div>
+                                <div class="typing-dot"></div>
+                        </div>
+                </div>
+                
+                <div class="chat-input-container">
+                        <div class="input-group">
+                                <textarea 
+                                        class="chat-input" 
+                                        id="messageInput" 
+                                        placeholder="Type your message here..." 
+                                        rows="1"
+                                ></textarea>
+                                <button class="send-button" id="sendButton">
+                                        Send
+                                </button>
+                        </div>
+                </div>
+        </div>
 
-	<script>
+        <script>
                 const chatMessages = document.getElementById('chatMessages');
                 const messageInput = document.getElementById('messageInput');
                 const sendButton = document.getElementById('sendButton');
@@ -386,49 +390,79 @@
 
                 let isRAGMode = false;
 
-		// Toggle mode functionality
-		modeToggle.addEventListener('click', function() {
-			isRAGMode = !isRAGMode;
-			this.classList.toggle('active', isRAGMode);
-			modeLabel.textContent = isRAGMode ? 'RAG' : 'LLM';
-			
-			// Add visual feedback
-			addMessage(`Switched to ${isRAGMode ? 'RAG' : 'LLM'} mode`, false);
-		});
+                // Toggle mode functionality
+                modeToggle.addEventListener('click', function() {
+                        isRAGMode = !isRAGMode;
+                        this.classList.toggle('active', isRAGMode);
+                        modeLabel.textContent = isRAGMode ? 'RAG' : 'LLM';
+                        
+                        // Add visual feedback
+                        addMessage(`Switched to ${isRAGMode ? 'RAG' : 'LLM'} mode`, false);
+                });
 
-		// Auto-resize textarea
-		messageInput.addEventListener('input', function() {
-			this.style.height = 'auto';
-			this.style.height = Math.min(this.scrollHeight, 100) + 'px';
-		});
+                // Auto-resize textarea
+                messageInput.addEventListener('input', function() {
+                        this.style.height = 'auto';
+                        this.style.height = Math.min(this.scrollHeight, 100) + 'px';
+                });
 
-		// Send message on Enter (but allow Shift+Enter for new lines)
-		messageInput.addEventListener('keydown', function(e) {
-			if (e.key === 'Enter' && !e.shiftKey) {
-				e.preventDefault();
-				sendMessage();
-			}
-		});
+                // Send message on Enter (but allow Shift+Enter for new lines)
+                messageInput.addEventListener('keydown', function(e) {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault();
+                                sendMessage();
+                        }
+                });
 
                 sendButton.addEventListener('click', sendMessage);
                 ingestButton.addEventListener('click', ingestFolder);
 
-		function addMessage(content, isUser = false, isError = false) {
-			const messageDiv = document.createElement('div');
-			if (isError) {
-				messageDiv.className = 'error-message';
-			} else {
-				messageDiv.className = isUser ? 'user-message' : 'bot-message';
-			}
-			messageDiv.textContent = content;
-			chatMessages.appendChild(messageDiv);
-			chatMessages.scrollTop = chatMessages.scrollHeight;
-		}
+                function normalizeMessagePayload(data) {
+                        // Back-compat with old `{ response: "..." }`
+                        if (data?.message && typeof data.message.content === 'string') return data.message;
+                        if (typeof data?.response === 'string') return { format: 'text', content: data.response };
+                        return { format: 'text', content: String(data ?? '') };
+                }
 
-		function showTypingIndicator() {
-			typingIndicator.style.display = 'block';
-			chatMessages.scrollTop = chatMessages.scrollHeight;
-		}
+                function renderContentInto(el, payload) {
+                        const { format, content } = payload || {};
+                        if (format === 'markdown') {
+                                const html = DOMPurify.sanitize(marked.parse(content || ''));
+                                el.innerHTML = html;
+                        } else {
+                                el.textContent = content || '';
+                                el.style.whiteSpace = 'pre-wrap'; // keep \n in plaintext
+                        }
+                }
+
+                function addMessage(payloadOrString, isUser = false, isError = false) {
+                        const messageDiv = document.createElement('div');
+                        messageDiv.className = isError
+                                ? 'error-message'
+                                : (isUser ? 'user-message' : 'bot-message');
+
+                        // Keep user/error as plain text for safety
+                        if (isUser || isError) {
+                                const text = typeof payloadOrString === 'string'
+                                        ? payloadOrString
+                                        : (payloadOrString?.content ?? String(payloadOrString ?? ''));
+                                messageDiv.textContent = text;
+                                messageDiv.style.whiteSpace = 'pre-wrap';
+                        } else {
+                                const payload = (typeof payloadOrString === 'string')
+                                        ? { format: 'text', content: payloadOrString }
+                                        : payloadOrString;
+                                renderContentInto(messageDiv, payload);
+                        }
+
+                        chatMessages.appendChild(messageDiv);
+                        chatMessages.scrollTop = chatMessages.scrollHeight;
+                }
+
+                function showTypingIndicator() {
+                        typingIndicator.style.display = 'block';
+                        chatMessages.scrollTop = chatMessages.scrollHeight;
+                }
 
                 function hideTypingIndicator() {
                         typingIndicator.style.display = 'none';
@@ -448,12 +482,15 @@
                         })
                         .then(response => response.json())
                         .then(data => {
+                                hideTypingIndicator();
                                 if (data.error) {
                                         addMessage(data.error, false, true);
-                                } else {
-                                        addMessage(`Ingested ${data.files_ingested} files.`, false);
+                                        return;
                                 }
+                                const payload = normalizeMessagePayload(data);
+                                addMessage(payload, false);
                         })
+
                         .catch(error => {
                                 console.error('Error:', error);
                                 addMessage('Error ingesting folder.', false, true);
@@ -463,57 +500,59 @@
                         });
                 }
 
-		function sendMessage() {
-			const message = messageInput.value.trim();
-			if (!message) return;
+                function sendMessage() {
+                        const message = messageInput.value.trim();
+                        if (!message) return;
 
-			// Add user message to chat
-			addMessage(message, true);
-			
-			// Clear input and reset height
-			messageInput.value = '';
-			messageInput.style.height = 'auto';
-			
-			// Disable send button and show typing indicator
-			sendButton.disabled = true;
-			showTypingIndicator();
+                        // Add user message to chat
+                        addMessage(message, true);
+                        
+                        // Clear input and reset height
+                        messageInput.value = '';
+                        messageInput.style.height = 'auto';
+                        
+                        // Disable send button and show typing indicator
+                        sendButton.disabled = true;
+                        showTypingIndicator();
 
-			// Choose endpoint based on mode
-			const endpoint = isRAGMode ? '/rag' : '/chat';
+                        // Choose endpoint based on mode
+                        const endpoint = isRAGMode ? '/rag' : '/chat';
 
-			// Send to Flask backend
-			fetch(endpoint, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({ message: message })
-			})
-			.then(response => response.json())
-			.then(data => {
-				hideTypingIndicator();
-				if (data.error) {
-					addMessage(data.error, false, true);
-				} else {
-					addMessage(data.response, false);
-				}
-			})
-			.catch(error => {
-				hideTypingIndicator();
-				console.error('Error:', error);
-				addMessage('Sorry, there was an error connecting to the server. Please try again.', false, true);
-			})
-			.finally(() => {
-				sendButton.disabled = false;
-				messageInput.focus();
-			});
-		}
+                        // Send to Flask backend
+                        fetch(endpoint, {
+                                method: 'POST',
+                                headers: {
+                                        'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify({ message: message })
+                        })
+                        .then(response => response.json())
+                        .then(data => {
+                                hideTypingIndicator();
+                                if (data.error) {
+                                        addMessage(data.error, false, true);
+                                        return;
+                                }
+                                const payload = normalizeMessagePayload(data);
+                                addMessage(payload, false);
+                        })
 
-		// Focus input on page load
-		window.addEventListener('load', () => {
-			messageInput.focus();
-		});
-	</script>
-	<!-- MOBILE VERSION -->
+                        .catch(error => {
+                                hideTypingIndicator();
+                                console.error('Error:', error);
+                                addMessage('Sorry, there was an error connecting to the server. Please try again.', false, true);
+                        })
+                        .finally(() => {
+                                sendButton.disabled = false;
+                                messageInput.focus();
+                        });
+                }
+
+                // Focus input on page load
+                window.addEventListener('load', () => {
+                        messageInput.focus();
+                });
+        </script>
+        <!-- MOBILE VERSION -->
 </body>
 </html>

--- a/chat_app/templates/index_mobile.html
+++ b/chat_app/templates/index_mobile.html
@@ -218,12 +218,17 @@
 			color: #a0aec0;
 		}
 
-		.chat-input:focus {
-			outline: none;
-			border-color: #f59e0b;
-			box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
-			background: rgba(74, 85, 104, 0.95);
-		}
+                .chat-input:focus {
+                        outline: none;
+                        border-color: #f59e0b;
+                        box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
+                        background: rgba(74, 85, 104, 0.95);
+                }
+
+                .chat-input.dragover {
+                        border-color: #f59e0b;
+                        background: rgba(74, 85, 104, 0.9);
+                }
 
 		.send-button {
 			padding: 12px 18px;
@@ -247,11 +252,24 @@
 			box-shadow: 0 6px 16px rgba(245, 158, 11, 0.4);
 		}
 
-		.send-button:disabled {
-			opacity: 0.6;
-			cursor: not-allowed;
-			transform: none;
-		}
+                .send-button:disabled {
+                        opacity: 0.6;
+                        cursor: not-allowed;
+                        transform: none;
+                }
+
+                .recursive-option {
+                        display: flex;
+                        align-items: center;
+                        color: #e2e8f0;
+                        gap: 6px;
+                        font-size: 0.85rem;
+                }
+
+                .recursive-option input {
+                        width: 14px;
+                        height: 14px;
+                }
 
 		.error-message {
 			background: rgba(220, 38, 38, 0.2);
@@ -284,18 +302,26 @@
 </head>
 <body>
 	<div class="chat-container">
-		<div class="chat-header">
-			<h1 class="header-title">VobaChat</h1>
-			<div class="mode-toggle">
-				<span class="mode-label" id="modeLabel">LLM</span>
-				<div class="toggle-switch" id="modeToggle">
-					<div class="toggle-slider"></div>
-				</div>
-				<span class="mode-label">RAG</span>
-			</div>
-		</div>
-		
-		<div class="chat-messages" id="chatMessages">
+                <div class="chat-header">
+                        <h1 class="header-title">VobaChat</h1>
+                        <div class="mode-toggle">
+                                <span class="mode-label" id="modeLabel">LLM</span>
+                                <div class="toggle-switch" id="modeToggle">
+                                        <div class="toggle-slider"></div>
+                                </div>
+                                <span class="mode-label">RAG</span>
+                        </div>
+                </div>
+
+                <div class="chat-input-container">
+                        <div class="input-group">
+                                <input type="text" class="chat-input" id="folderPath" placeholder="Folder path">
+                                <label class="recursive-option"><input type="checkbox" id="recursive">Recursive</label>
+                                <button class="send-button" id="ingestButton">Ingest</button>
+                        </div>
+                </div>
+
+                <div class="chat-messages" id="chatMessages">
 			<div class="bot-message">
 				Hello! I'm VobaChat, your AI assistant. How can I help you today?
 			</div>
@@ -325,14 +351,40 @@
 	</div>
 
 	<script>
-		const chatMessages = document.getElementById('chatMessages');
-		const messageInput = document.getElementById('messageInput');
-		const sendButton = document.getElementById('sendButton');
-		const typingIndicator = document.getElementById('typingIndicator');
-		const modeToggle = document.getElementById('modeToggle');
-		const modeLabel = document.getElementById('modeLabel');
+                const chatMessages = document.getElementById('chatMessages');
+                const messageInput = document.getElementById('messageInput');
+                const sendButton = document.getElementById('sendButton');
+                const typingIndicator = document.getElementById('typingIndicator');
+                const modeToggle = document.getElementById('modeToggle');
+                const modeLabel = document.getElementById('modeLabel');
+                const folderInput = document.getElementById('folderPath');
+                const ingestButton = document.getElementById('ingestButton');
+                const recursiveCheckbox = document.getElementById('recursive');
 
-		let isRAGMode = false;
+                window.addEventListener('dragover', (e) => e.preventDefault());
+                window.addEventListener('drop', (e) => e.preventDefault());
+
+                folderInput.addEventListener('dragover', (e) => {
+                        e.preventDefault();
+                        folderInput.classList.add('dragover');
+                });
+                folderInput.addEventListener('dragleave', () => {
+                        folderInput.classList.remove('dragover');
+                });
+                folderInput.addEventListener('drop', (e) => {
+                        e.preventDefault();
+                        folderInput.classList.remove('dragover');
+                        let droppedPath = e.dataTransfer.getData('text/plain') || e.dataTransfer.getData('text/uri-list');
+                        if (!droppedPath && e.dataTransfer.files.length > 0) {
+                                const file = e.dataTransfer.files[0];
+                                droppedPath = file.path || file.name;
+                        }
+                        if (droppedPath) {
+                                folderInput.value = droppedPath.replace(/^file:\/\//, '');
+                        }
+                });
+
+                let isRAGMode = false;
 
 		// Toggle mode functionality
 		modeToggle.addEventListener('click', function() {
@@ -358,7 +410,8 @@
 			}
 		});
 
-		sendButton.addEventListener('click', sendMessage);
+                sendButton.addEventListener('click', sendMessage);
+                ingestButton.addEventListener('click', ingestFolder);
 
 		function addMessage(content, isUser = false, isError = false) {
 			const messageDiv = document.createElement('div');
@@ -377,9 +430,38 @@
 			chatMessages.scrollTop = chatMessages.scrollHeight;
 		}
 
-		function hideTypingIndicator() {
-			typingIndicator.style.display = 'none';
-		}
+                function hideTypingIndicator() {
+                        typingIndicator.style.display = 'none';
+                }
+
+                function ingestFolder() {
+                        const folder = folderInput.value.trim();
+                        const recursive = recursiveCheckbox.checked;
+                        if (!folder) return;
+                        ingestButton.disabled = true;
+                        fetch('/ingest', {
+                                method: 'POST',
+                                headers: {
+                                        'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify({ folder: folder, recursive: recursive })
+                        })
+                        .then(response => response.json())
+                        .then(data => {
+                                if (data.error) {
+                                        addMessage(data.error, false, true);
+                                } else {
+                                        addMessage(`Ingested ${data.files_ingested} files.`, false);
+                                }
+                        })
+                        .catch(error => {
+                                console.error('Error:', error);
+                                addMessage('Error ingesting folder.', false, true);
+                        })
+                        .finally(() => {
+                                ingestButton.disabled = false;
+                        });
+                }
 
 		function sendMessage() {
 			const message = messageInput.value.trim();

--- a/tests/test_chatapp.py
+++ b/tests/test_chatapp.py
@@ -56,7 +56,8 @@ class TestChatApp(unittest.TestCase):
         data = json.loads(response.data)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['response'], "Mocked response")
+        self.assertEqual(data['message']['content'], "Mocked response")
+        self.assertEqual(data['message']['format'], "markdown")
         self.MockLLMHandler.return_value.chat_next.assert_called_once_with("Hello")
 
     def test_rag_route(self):
@@ -64,8 +65,9 @@ class TestChatApp(unittest.TestCase):
         data = json.loads(response.data)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['response'], "Mocked response")
-        self.assertEqual(data['sources'], ["Mocked sources"])
+        self.assertEqual(data['message']['content'], "Mocked response")
+        self.assertEqual(data['message']['format'], "markdown")
+        self.assertEqual(data['meta']['sources'], ["Mocked sources"])
         self.MockRAGRetriever.return_value.build_messages.assert_called_once_with("Hello", n_results=5)
         self.MockLLMHandler.return_value.chat_messages.assert_called_once_with(["Mocked message"], reset=True)
 

--- a/tests/test_chatapp.py
+++ b/tests/test_chatapp.py
@@ -3,65 +3,82 @@ import unittest
 from flask import json
 from chat_app.chat_app import ChatApp
 
+
 class TestChatApp(unittest.TestCase):
-	def setUp(self):
-		patcher = patch('chat_app.chat_app.LLMHandler')
-		patcher_store = patch('chat_app.chat_app.RAGStore')
-		patcher_rag = patch('chat_app.chat_app.RAGRetriever')
+    def setUp(self):
+        patcher = patch('chat_app.chat_app.LLMHandler')
+        patcher_store = patch('chat_app.chat_app.RAGStore')
+        patcher_rag = patch('chat_app.chat_app.RAGRetriever')
+        patcher_scan = patch('chat_app.chat_app.Scanner')
 
-		self.MockLLMHandler = patcher.start()
-		self.MockRAGStore = patcher_store.start()
-		self.MockRAGRetriever = patcher_rag.start()
+        self.MockLLMHandler = patcher.start()
+        self.MockRAGStore = patcher_store.start()
+        self.MockRAGRetriever = patcher_rag.start()
+        self.MockScanner = patcher_scan.start()
 
-		self.addCleanup(patcher.stop)
-		self.addCleanup(patcher_store.stop)
-		self.addCleanup(patcher_rag.stop)
+        self.addCleanup(patcher.stop)
+        self.addCleanup(patcher_store.stop)
+        self.addCleanup(patcher_rag.stop)
+        self.addCleanup(patcher_scan.stop)
 
-		mock_llm_instance = self.MockLLMHandler.return_value
-		mock_rag_instance = self.MockRAGRetriever.return_value
-		mock_llm_instance.chat_next.return_value = "Mocked response"
-		mock_rag_instance.new_prompt_and_sources.return_value = ("Mocked prompt", "Mocked sources")
+        mock_llm_instance = self.MockLLMHandler.return_value
+        mock_rag_instance = self.MockRAGRetriever.return_value
+        mock_llm_instance.chat_next.return_value = "Mocked response"
+        mock_llm_instance.chat_messages.return_value = "Mocked response"
+        mock_rag_instance.build_messages.return_value = (["Mocked message"], ["Mocked sources"])
+        self.MockScanner.return_value.scan.return_value = ["file1", "file2"]
+        self.MockRAGStore.return_value.ingest.return_value = ["id1", "id2"]
 
-		self.chat_app = ChatApp("dummy-model-id")
-		self.app = self.chat_app.app
-		self.client = self.app.test_client()
+        self.chat_app = ChatApp("dummy-model-id")
+        self.app = self.chat_app.app
+        self.client = self.app.test_client()
 
-	def test_index_route(self):
-		agents = {
-			"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36": "desktop",
-			"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:116.0) Gecko/20100101 Firefox/116.0": "desktop",
-			"Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1": "mobile",
-			"Mozilla/5.0 (iPad; CPU OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/115.0.5790.71 Mobile/15E148 Safari/604.1": "mobile"
-		}
-		for agent, expected in agents.items():
-			response = self.client.get('/', headers={"User-Agent": agent})
-			html = response.data.decode('utf-8')
+    def test_index_route(self):
+        agents = {
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36": "desktop",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:116.0) Gecko/20100101 Firefox/116.0": "desktop",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1": "mobile",
+            "Mozilla/5.0 (iPad; CPU OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/115.0.5790.71 Mobile/15E148 Safari/604.1": "mobile",
+        }
+        for agent, expected in agents.items():
+            response = self.client.get('/', headers={"User-Agent": agent})
+            html = response.data.decode('utf-8')
 
-			if expected == "mobile":
-				self.assertIn("<!-- MOBILE VERSION -->", html)
-				self.assertNotIn("<!-- DESKTOP VERSION -->", html)
-			else:
-				self.assertIn("<!-- DESKTOP VERSION -->", html)
-				self.assertNotIn("<!-- MOBILE VERSION -->", html)
+            if expected == "mobile":
+                self.assertIn("<!-- MOBILE VERSION -->", html)
+                self.assertNotIn("<!-- DESKTOP VERSION -->", html)
+            else:
+                self.assertIn("<!-- DESKTOP VERSION -->", html)
+                self.assertNotIn("<!-- MOBILE VERSION -->", html)
 
+    def test_chat_route(self):
+        response = self.client.post('/chat', json={"message": "Hello"})
+        data = json.loads(response.data)
 
-	def test_chat_route(self):
-		response = self.client.post('/chat', json={"message": "Hello"})
-		data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['response'], "Mocked response")
+        self.MockLLMHandler.return_value.chat_next.assert_called_once_with("Hello")
 
-		self.assertEqual(response.status_code, 200)
-		self.assertEqual(data['response'], "Mocked response")
-		self.MockLLMHandler.return_value.chat_next.assert_called_once_with("Hello")
+    def test_rag_route(self):
+        response = self.client.post('/rag', json={"message": "Hello"})
+        data = json.loads(response.data)
 
-	def test_rag_route(self):
-		response = self.client.post('/rag', json={"message": "Hello"})
-		data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['response'], "Mocked response")
+        self.assertEqual(data['sources'], ["Mocked sources"])
+        self.MockRAGRetriever.return_value.build_messages.assert_called_once_with("Hello", n_results=5)
+        self.MockLLMHandler.return_value.chat_messages.assert_called_once_with(["Mocked message"], reset=True)
 
-		self.assertEqual(response.status_code, 200)
-		self.assertEqual(data['response'], "Mocked response")
-		self.MockRAGRetriever.return_value.new_prompt_and_sources.assert_called_once_with("Hello")
-		self.MockLLMHandler.return_value.chat_next.assert_called_once_with("Mocked prompt")
+    def test_ingest_route(self):
+        response = self.client.post('/ingest', json={"folder": "/tmp", "recursive": True})
+        data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['files_ingested'], 2)
+        self.MockScanner.return_value.scan.assert_called_once_with("/tmp", recursively=True)
+        self.MockRAGStore.return_value.ingest.assert_called_once_with(["file1", "file2"])
 
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add `/ingest` endpoint to allow ingesting all files in a chosen folder
- extend desktop and mobile templates with folder path input, drag-and-drop support, and recursive toggle
- cover new endpoint with unit tests
- fix drag-and-drop handling by preventing default navigation and extracting folder paths from dropped items

## Testing
- `pip install -q flask transformers torch pillow chromadb` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask', 'transformers', 'torch', 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68aba318272c8324a653150913bee3ac