### PR TITLE
Add JSON fallback for settings and round-trip tests

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+import tempfile
+from unittest import mock
+from chat_app.settings import Settings, save_settings, load_settings
+
+
+class TestSettingsRoundtrip(unittest.TestCase):
+    def test_round_trip_with_tomli_w(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "settings.toml")
+            original = Settings()
+            original.app.port = 1234
+            save_settings(original, path)
+            loaded = load_settings(path)
+            self.assertEqual(loaded, original)
+            self.assertTrue(os.path.exists(path))
+            self.assertFalse(os.path.exists(os.path.splitext(path)[0] + ".json"))
+
+    def test_round_trip_without_tomli_w(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "settings.toml")
+            original = Settings()
+            original.app.port = 4321
+            from chat_app import settings as cfg
+            with mock.patch.object(cfg, "tomli_w", None):
+                save_settings(original, path)
+                loaded = load_settings(path)
+            self.assertEqual(loaded, original)
+            self.assertFalse(os.path.exists(path))
+            self.assertTrue(os.path.exists(os.path.splitext(path)[0] + ".json"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `load_settings` to read JSON files when `tomli_w` is missing
- fix mutable defaults in settings dataclasses
- test configuration round-trip with and without `tomli_w`

## Testing
- `pytest tests/test_settings.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask', 'transformers', 'torch', 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68b94b4f65c0832494e7234146e54d5f