### PR TITLE
Fix hybrid RAG message context assembly

### DIFF
--- a/chat_app/rag_retriever.py
+++ b/chat_app/rag_retriever.py
@@ -83,7 +83,7 @@ class RAGRetriever:
 		scores_nested = results.get("scores", [[]])
 		normalized_scores_nested = results.get("normalized_scores", [[]])
 
-		fmt_ids = ()
+		fmt_ids = []
 		def _fmt_id(meta, idx):
 			sf = (meta or {}).get("source_file", "source")
 			ch = (meta or {}).get("chunk_index", idx)
@@ -93,10 +93,10 @@ class RAGRetriever:
 
 		chunks = []
 		for i, txt in enumerate(texts_nested[0] if texts_nested else []):
-			txt = gr.redact_private(txt)
-			txt = "**Malicous prompt detected**" if gr.looks_sus(txt) else txt
+			txt = self.gr.redact_private(txt)
+			txt = "**Malicous prompt detected**" if self.gr.looks_sus(txt) else txt
 			meta = metas_nested[0][i] if (metas_nested and metas_nested[0] and i < len(metas_nested[0])) else {}
-			norm_score = normalized_scores_nested[0][i] if (normalized_scores_nested and normalized_scores_nested[0]) else None
+			norm_score = (normalized_scores_nested[0][i] if (normalized_scores_nested and normalized_scores_nested[0] and i < len(normalized_scores_nested[0])) else None)
 			warning = label_war if (norm_score and norm_score < .65) else None
 			if warning:
 				chunks.append(f"[{warning}]\n[score: {norm_score}]\n[{_fmt_id(meta, i)}]\n{txt}")

--- a/tests/test_rag_retriever.py
+++ b/tests/test_rag_retriever.py
@@ -1,0 +1,35 @@
+import unittest
+from chat_app.rag_retriever import RAGRetriever
+
+class DummyCollection:
+    def get(self, ids, include):
+        return {"ids": [], "documents": [], "metadatas": []}
+
+class DummyStore:
+    def __init__(self):
+        self.collection = DummyCollection()
+    def query(self, query_text, n_results, include):
+        return {
+            "ids": [["1"]],
+            "documents": [["alpha context"]],
+            "metadatas": [[{"source_file": "a.txt", "chunk_index": 0}]],
+            "distances": [[0.1]],
+        }
+    def sparse_query(self, query_text, n_results):
+        return {
+            "ids": [["1"]],
+            "documents": [["alpha context"]],
+            "metadatas": [[{"source_file": "a.txt", "chunk_index": 0}]],
+            "scores": [[1.0]],
+        }
+
+class TestRAGRetriever(unittest.TestCase):
+    def test_build_messages_hybrid_has_context(self):
+        rag = RAGRetriever(DummyStore())
+        messages, sources, fmt_ids = rag.build_messages_hybrid("question", top_k=1)
+        self.assertIn("alpha context", messages[1]["content"])
+        self.assertEqual(len(sources), 1)
+        self.assertEqual(fmt_ids, ["a.txt#0"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- use Guardrails instance in `build_messages_hybrid`
- collect formatted chunk ids and normalize score access
- add unit test ensuring hybrid messages include context

## Testing
- `pytest tests/test_rag_retriever.py::TestRAGRetriever::test_build_messages_hybrid_has_context -q`
- `pytest tests/test_rag_store.py::TestRAGStore::test_query_top1 -q` *(fails: ProxyError: Unable to connect to proxy when downloading model)*


------
https://chatgpt.com/codex/tasks/task_e_68b95c60aeec8324b0edb1f8881c5c5a